### PR TITLE
Update instrumenter.js

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -87,8 +87,7 @@ extend(Instrumenter.prototype, {
       this._compiler = this._createCompiler();
     }
 
-    this._compiler.options_.filename = filename;
-    var compiled = this._compiler.compile(code);
+    var compiled = this._compiler.compile(code, filename);
 
     return {
       code: compiled,


### PR DESCRIPTION
I had problem using your lib, and it seems I found a solution. 
In traceur: https://github.com/google/traceur-compiler/blob/master/src/Compiler.js#L132 you can pass the filename argument to compile method.
I also remove `this._compiler.options_.filename = filename;` which seems to do nothing (also based on https://github.com/google/traceur-compiler/blob/master/src/Compiler.js)
